### PR TITLE
Adds support for Windows platform

### DIFF
--- a/set_window_title.py
+++ b/set_window_title.py
@@ -213,6 +213,6 @@ class SetWindowTitle(EventListener):
         for w in Window.all():
           if official_title in w.title:
             w.title = new_title
-            self.window_handle_cache[window.id()] = w
+            # self.window_handle_cache[window.id()] = w
       else:
         w.title = new_title


### PR DESCRIPTION
- Now checks the `sublime.platform()` in key places.
- `rename_window()` now implemented on Windows by calling the User32 API directly via ctypes.
- Currently it just loops through all windows, searching for the any with the "official_title" as a substring of its title, and then replaces its title.