### PR TITLE
Adding support for displaying multiple folder names as project name

### DIFF
--- a/set_window_title.py
+++ b/set_window_title.py
@@ -143,10 +143,9 @@ class SetWindowTitle(EventListener):
     project = window.project_file_name()
     if not project:
       folders = window.folders()
-      project = folders[0] if folders else None
-    if project:
-      project = os.path.basename(project)
-      project = os.path.splitext(project)[0]
+      project = ", ".join( [get_folder_name(x) for x in folders] ) if folders else None
+    else:
+      project = get_folder_name(project)
 
     return project
 
@@ -205,6 +204,8 @@ class SetWindowTitle(EventListener):
     else:
       w.title = new_title
 
+def get_folder_name(path):
+    return os.path.splitext( os.path.basename( path ) )[0]
 
 def get_official_title(view, project, settings):
   """Returns the official name for a given view.


### PR DESCRIPTION
In the original window title, when a window contained several base folders, all folder names are displayed: `(A, B, C)`. Previously, this would break this plugins behaviour. This pull request fixes that.

Unfortunately I couldn't get the test to work, and only tested it directly on Linux, where it appears to work perfectly.

Thank you for this neat little plugin! Will save me multiple confused clicks per day and is generally well written :)